### PR TITLE
changed filter for multi-language multi-shop

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -1433,7 +1433,7 @@ class GShoppingFlux extends Module
 			 
 		// Multishops filter		
 		if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && count(Shop::getShops(true, null, true)) > 1) {
-            $sql .= ' AND gc.id_shop = '.$id_shop.' AND pl.id_shop = '.$id_shop.' AND ps.id_shop = '.$id_shop;
+            $sql .= ' AND gc.id_shop = '.$id_shop.' AND pl.id_shop = '.$id_shop.' AND ps.id_shop = '.$id_shop.' AND gl.id_shop = '.$id_shop;
         }
 		
 		// Check EAN13


### PR DESCRIPTION
Added ".' AND gl.id_shop = '.$id_shop" at the end of line 1436 as a solution to the duplicate items issue in an Multi-language Multi-shop environment. See forum http://www.prestashop.com/forums/topic/381026-free-module-google-shopping-flux/page-4#entry1910862