### PR TITLE
Revert "Update Create Table"

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -113,7 +113,7 @@ class GShoppingFlux extends Module
 			`gender` VARCHAR( 8 ) NOT NULL,
 			`age_group` VARCHAR( 8 ) NOT NULL,
 			`id_shop` INT(11) UNSIGNED NOT NULL,
-			PRIMARY KEY (`id_shop`)
+			INDEX (`id_shop`)
 		) ENGINE = '._MYSQL_ENGINE_.' CHARACTER SET utf8 COLLATE utf8_general_ci;') &&
 			Db::getInstance()->execute('
 			 CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'gshoppingflux_lang` (
@@ -121,7 +121,7 @@ class GShoppingFlux extends Module
 			`id_lang` INT(11) UNSIGNED NOT NULL,
 			`id_shop` INT(11) UNSIGNED NOT NULL,
 			`gcategory` VARCHAR( 255 ) NOT NULL,
-			PRIMARY KEY ( `id_gcategory` , `id_lang`, `id_shop`)
+			INDEX ( `id_gcategory` , `id_lang`, `id_shop`)
 		) ENGINE = '._MYSQL_ENGINE_.' CHARACTER SET utf8 COLLATE utf8_general_ci;'));
 	}
 


### PR DESCRIPTION
Reverts dim00z/gshoppingflux#2
Suite à l'affectation d'une clé primaire, les sauvegardes de paramètres concernant les catégories ne se font plus correctement sur certaines configs. Je supprime donc la mise à jour, même si cela semble plus évident à gérer sous phpMyAdmin...