### PR TITLE
Description limit in line with Product Feed specs

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -2047,7 +2047,7 @@ class GShoppingFlux extends Module
 		$xml_googleshopping = '';
 		$id_lang = (int)$lang['id_lang'];
 		$title_limit  = 70;
-		$description_limit = 10000;
+		$description_limit = 4990;
 		$languages = Language::getLanguages();
 		$tailleTabLang = sizeof($languages);
 		$this->context->language->id = $id_lang;


### PR DESCRIPTION
Based on https://support.google.com/merchants/answer/188494?hl=en-AU , description character limit needs to be 5000 characters or less