### PR TITLE
[Bugfix] fix Combination firing

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -1966,6 +1966,12 @@ class GShoppingFlux extends Module
 
 		foreach ($products as $product) {
 			$p = new Product($product['id_product'], true, $id_lang, $id_shop, $this->context);
+			
+			$attributeCombinations = null;
+			if ($this->module_conf['export_attributes'] == 1) {
+				$attributeCombinations = $p->getAttributeCombinations($id_lang);
+			}
+
 			$attributeCombinations = $p->getAttributeCombinations($id_lang);
 
 			if ($this->module_conf['mpn_type'] == 'reference' && !empty($product['reference']))

--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -1972,8 +1972,6 @@ class GShoppingFlux extends Module
 				$attributeCombinations = $p->getAttributeCombinations($id_lang);
 			}
 
-			$attributeCombinations = $p->getAttributeCombinations($id_lang);
-
 			if ($this->module_conf['mpn_type'] == 'reference' && !empty($product['reference']))
 				$product['pid'] = $product['reference'];
 			else if ($this->module_conf['mpn_type'] == 'supplier_reference' && !empty($product['supplier_reference']))


### PR DESCRIPTION
In live testing with Prestashop sites having 100,000 to millions of individual product combinations, grabbing every single combination when they may not turn up in the Merchant XML file spikes server / writing load.

This fix only uses the getAttributeCombinations function when the store wants every single combination.