### PR TITLE
Update gshoppingflux.php to use <g:additional_image_link>

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -2163,7 +2163,11 @@ class GShoppingFlux extends Module
 		foreach ($images as $im) {
 			$image = $this->context->link->getImageLink($product['link_rewrite'], $product['id_product'].'-'.$im['id_image'], $image_type);
 			$image = preg_replace('*http://'.Tools::getHttpHost().'/*', $this->uri, $image);
-			$xml_googleshopping .= '<g:image_link><![CDATA['.$image.']]></g:image_link>'."\n";
+			if ($im['cover'] == 1 ) {
+				$xml_googleshopping .= '<g:image_link><![CDATA['.$image.']]></g:image_link>'."\n";
+			} else {
+				$xml_googleshopping .= '<g:additional_image_link><![CDATA['.$image.']]></g:additional_image_link>'."\n";
+			}
 			// max images by product
 			if (++$nbimages == 10)
 				break;


### PR DESCRIPTION
Hi dim00z,
as suggested in this Urs Meier's post:
https://www.prestashop.com/forums/topic/381026-free-module-google-shopping-flux/?p=2299689

I applied the fix I propose you on my 1.6.2 version of the module and it works!

Google policy is to accept only <g:additional_image_link>(..) </g:additional_image_link> after the first <g:image_link>(..)</g:image_link> tag on each product item.

Thank you so much for your module!
By LucaPresta (in the prestashop forum).