### PR TITLE
Fix "Undefined variable: attributesResume"

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -2200,7 +2200,7 @@ class GShoppingFlux extends Module
         foreach ($products as $product) {
             $p = new Product($product['id_product'], true, $id_lang, $id_shop, $this->context);
 
-            $attributeCombinations = null;
+            $attributesResume = null;
             if ($this->module_conf['export_attributes'] == 1) {
                 $attributesResume = $p->getAttributesResume($id_lang);
             }


### PR DESCRIPTION
Hi! Thanks for this module, works just fine for our Prestashop installation. However, I noticed the following notices in the Apache error log:

`Undefined variable: attributesResume in /[...]/gshoppingflux.php on line 2212`

The script defines an unused variable $attributeCombinations some lines before, so I assume this should have been $attributesResume .