### PR TITLE
Fixed 404 error in PS >=9 for category edit

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -2465,7 +2465,7 @@ class GShoppingFlux extends Module
         ];
         $helper->title = $this->l('Export languages and currencies');
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->tpl_vars = [
             'languages' => $this->context->controller->getLanguages(),
         ];
@@ -2574,7 +2574,7 @@ class GShoppingFlux extends Module
         $helper->module = $this;
         $helper->title = $this->l('Google categories');
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
 
         return $helper->generateList($gcategories, $fields_list);
     }


### PR DESCRIPTION
Clicking the **Edit** action button in the **Google categories** list (or the **Export languages and currencies** list) on the module configuration page produces a **404 Not Found** on PrestaShop 9.x

Example of the broken URL that the browser ends up requesting:

```
https://shop.example/admin.../improve/modules/manage/action/configure/index.php?controller=AdminModules&configure=gshoppingflux&updategshoppingflux=&id_gcategory=2&token=...
```

Note the `improve/modules/manage/action/configure/index.php` segment — there is no such file under the Symfony module manager route, so PrestaShop returns 404.

Tested on Prestashop 9.0 and 9.1